### PR TITLE
Fix wallet analysis data retrieval and display

### DIFF
--- a/agents/agent1-wia/package-lock.json
+++ b/agents/agent1-wia/package-lock.json
@@ -17,9 +17,9 @@
         "winston": "^3.11.0"
       },
       "devDependencies": {
-        "@types/node": "^20.8.0",
+        "@types/node": "^20.19.10",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -448,9 +448,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "version": "20.19.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
+      "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1483,9 +1483,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/agents/agent1-wia/package.json
+++ b/agents/agent1-wia/package.json
@@ -32,8 +32,8 @@
     "winston": "^3.11.0"
   },
   "devDependencies": {
-    "@types/node": "^20.8.0",
+    "@types/node": "^20.19.10",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.9.2"
   }
-} 
+}

--- a/agents/agent1-wia/src/services/blockchain/BitcoinService.ts
+++ b/agents/agent1-wia/src/services/blockchain/BitcoinService.ts
@@ -118,10 +118,11 @@ export class BitcoinService {
       const balanceInSatoshi = response.data.balance;
       const balanceInBtc = balanceInSatoshi / 100000000; // Convert satoshi to BTC
       
-      // Get USD value from price service
-      const usdValue = await this.priceService.getTokenPrice('BTC', 'bitcoin');
+      // Get BTC price from price service and calculate USD value
+      const btcPrice = await this.priceService.getTokenPrice('BTC', 'bitcoin');
+      const usdValue = balanceInBtc * btcPrice;
       
-      logger.debug(`Bitcoin balance for ${address}: ${balanceInBtc} BTC ($${usdValue})`);
+      logger.debug(`Bitcoin balance for ${address}: ${balanceInBtc} BTC ($${usdValue.toFixed(2)})`);
       
       return {
         balance: balanceInBtc.toFixed(8),
@@ -150,10 +151,11 @@ export class BitcoinService {
       const balanceInSatoshi = fundedSum - spentSum;
       const balanceInBtc = balanceInSatoshi / 100000000; // Convert satoshi to BTC
       
-      // Get USD value from price service
-      const usdValue = await this.priceService.getTokenPrice('BTC', 'bitcoin');
+      // Get BTC price from price service and calculate USD value
+      const btcPrice = await this.priceService.getTokenPrice('BTC', 'bitcoin');
+      const usdValue = balanceInBtc * btcPrice;
       
-      logger.debug(`Bitcoin balance for ${address}: ${balanceInBtc} BTC ($${usdValue})`);
+      logger.debug(`Bitcoin balance for ${address}: ${balanceInBtc} BTC ($${usdValue.toFixed(2)})`);
       
       return {
         balance: balanceInBtc.toFixed(8),

--- a/agents/agent1-wia/src/services/blockchain/EVMService.ts
+++ b/agents/agent1-wia/src/services/blockchain/EVMService.ts
@@ -251,10 +251,11 @@ export class EVMService {
       const balance = await provider.getBalance(address);
       const balanceInUnits = ethers.formatEther(balance);
       
-      // Get USD value from price service
-      const usdValue = await this.priceService.getTokenPrice(chainConfig.symbol, chain);
+      // Get token price from price service and calculate USD value
+      const tokenPrice = await this.priceService.getTokenPrice(chainConfig.symbol, chain);
+      const usdValue = parseFloat(balanceInUnits) * tokenPrice;
       
-      logger.debug(`${chainConfig.name} balance for ${address}: ${balanceInUnits} ${chainConfig.symbol} ($${usdValue})`);
+      logger.debug(`${chainConfig.name} balance for ${address}: ${balanceInUnits} ${chainConfig.symbol} ($${usdValue.toFixed(2)})`);
       
       return {
         balance: balanceInUnits,
@@ -382,8 +383,9 @@ export class EVMService {
       const balance = await tokenContract.balanceOf(address);
       const formattedBalance = ethers.formatUnits(balance, tokenInfo.decimals);
       
-      // Get USD value from price service
-      const usdValue = await this.priceService.getTokenPrice(tokenInfo.tokenSymbol, chain);
+      // Get token price from price service and calculate USD value
+      const tokenPrice = await this.priceService.getTokenPrice(tokenInfo.tokenSymbol, chain);
+      const usdValue = parseFloat(formattedBalance) * tokenPrice;
       
       return {
         contractAddress,


### PR DESCRIPTION
Fixes incorrect USD value calculations for cryptocurrency balances by multiplying token price with the balance instead of just returning the price.

The previous implementation was fetching the token's price but directly assigning it as the `usdValue`, leading to incorrect `$0.00` or very small values on the frontend, even when a balance existed. This PR corrects the calculation to reflect the actual total USD value of the holdings.

---
<a href="https://cursor.com/background-agent?bcId=bc-944143ef-d408-4939-838d-77e3a1d43537">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-944143ef-d408-4939-838d-77e3a1d43537">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

